### PR TITLE
Shto weather.js, testet fillestare dhe konfigurimet për Jest/Babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    presets: ['@babel/preset-env'],
+  };
+  

--- a/src/__tests__/helpers.test.js
+++ b/src/__tests__/helpers.test.js
@@ -1,0 +1,33 @@
+// src/__tests__/helpers.test.js
+
+import helpers from '../js/helpers';
+
+describe('helpers.addInnerText', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `<div id="weatherInfo"></div>`;
+  });
+
+  test('e shton përshkrimin e motit në elementin e duhur', () => {
+    const text = 'Sot është me diell dhe 22°C';
+    const result = helpers().addInnerText('weatherInfo', text);
+
+    // Printo diçka që lidhet me motin në konzolë
+    console.log(`Informata e motit u shfaq: "${result}" në elementin #weatherInfo`);
+
+    expect(result).toBe(text);
+  });
+});
+
+describe('helpers.isColdWeather', () => {
+  test('kthen true për temperaturë nën 10°C', () => {
+    const result = helpers().isColdWeather(5);
+    console.log(`🧊 Temperaturë: 5°C ➝ Është e ftohtë: ${result}`);
+    expect(result).toBe(true);
+  });
+
+  test('kthen false për temperaturë mbi 10°C', () => {
+    const result = helpers().isColdWeather(15);
+   console.log(`🌤 Temperaturë: 15°C ➝ Është e ftohtë: ${result}`);
+    expect(result).toBe(false);
+  });
+});

--- a/src/__tests__/weather.test.js
+++ b/src/__tests__/weather.test.js
@@ -1,0 +1,23 @@
+// src/__tests__/weather.test.js
+
+import { formatTemperature } from '../js/weather';
+
+describe('formatTemperature', () => {
+  test('konverton 0°C në 32°F', () => {
+    const result = formatTemperature(0);
+    console.log('0°C →', result + '°F');
+    expect(result).toBe(32);
+  });
+
+  test('konverton 100°C në 212°F', () => {
+    const result = formatTemperature(100);
+    console.log('100°C →', result + '°F');
+    expect(result).toBe(212);
+  });
+
+  test('konverton 20°C në 68°F', () => {
+    const result = formatTemperature(20);
+    console.log('20°C →', result + '°F');
+    expect(result).toBe(68);
+  });
+});

--- a/src/jest.config.js
+++ b/src/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    testEnvironment: 'jsdom',
+    transform: {
+      "^.+\\.js$": "babel-jest"
+    },
+    transformIgnorePatterns: [
+      "/node_modules/(?!places.js)"
+    ]
+  };
+  

--- a/src/js/weather.js
+++ b/src/js/weather.js
@@ -1,0 +1,14 @@
+// src/js/weather.js
+
+// Merr të dhënat e motit nga API
+export async function getWeather(city) {
+    const response = await fetch(`https://api.weatherapi.com/v1/current.json?key=YOUR_API_KEY&q=${city}`);
+    const data = await response.json();
+    return data;
+  }
+  
+  // Konverton temperaturën nga Celsius në Fahrenheit
+  export function formatTemperature(celsius) {
+    return (celsius * 9 / 5) + 32;
+  }
+  


### PR DESCRIPTION
Çfarë shtova:
- `weather.js` me logjikën për marrjen e të dhënave të motit
- Dosja `__tests__/` me:
   - `helpers.test.js`
   - `weather.test.js`
- Konfigurimi i Jest në `jest.config.js`
- `babel.config.js` për transpile të kodit modern në testim

 Qëllimi:
- Të vendos bazën për testim automatik në projekt
- Të ndahet logjika e motit në një modul të qartë

 Testuar:
- Komandat `npm run test` funksionojnë me sukses
